### PR TITLE
support Ruby 1.8 by including rubygems

### DIFF
--- a/files/default/chef-handler-graphite.rb
+++ b/files/default/chef-handler-graphite.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+require "rubygems"
 require "simple-graphite"
 require "chef"
 require "chef/handler"


### PR DESCRIPTION
Ruby 1.8 does not include Rubygems by default, so an extra require line is needed.
