### PR TITLE
Chef run_status attributes may not exist

### DIFF
--- a/files/default/chef-handler-graphite.rb
+++ b/files/default/chef-handler-graphite.rb
@@ -36,8 +36,8 @@ class GraphiteReporting < Chef::Handler
     g.port = @graphite_port
 
     metrics = Hash.new
-    metrics[:updated_resources] = run_status.updated_resources.length
-    metrics[:all_resources] = run_status.all_resources.length
+    metrics[:updated_resources] = run_status.has_key? 'updated_resources' ? run_status.updated_resources.length : 0
+    metrics[:all_resources] = run_status.has_key? 'all_resources' ? run_status.all_resources.length : 0
     metrics[:elapsed_time] = run_status.elapsed_time
 
     # Graph metrics from the Ohai system-packages plugin (https://github.com/finnlabs/ohai-system_packages/)


### PR DESCRIPTION
I've experienced failed chef runs where the handler raised exceptions on run_status.updated_resources.length

```
2012-10-08_19:23:17.92303 [Mon, 08 Oct 2012 19:23:17 +0000] ERROR: Report handler GraphiteReporting raised #<NoMethodError: undefined method `length' for nil:NilClass>
2012-10-08_19:23:17.92304 [Mon, 08 Oct 2012 19:23:17 +0000] ERROR: /var/chef/cache/chef-handler-graphite.rb:38:in `report'
```

So this PR should fix that.
