### PR TITLE
Add ability to send detailed per-cookbook profiling data

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,3 +17,4 @@
 default['chef_client']['handler']['graphite']['host'] = nil
 default['chef_client']['handler']['graphite']['port'] = nil
 default['chef_client']['handler']['graphite']['prefix'] = "chef.#{node.chef_environment}.node.#{(node['hostname']||'').downcase}"
+default['chef_client']['handler']['graphite']['enable_profiling'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,6 +30,7 @@ if node['chef_client']['handler']['graphite']['host'] && node['chef_client']['ha
     source "#{Chef::Config[:file_cache_path]}/chef-handler-graphite.rb"
     arguments [
                 :metric_key => node['chef_client']['handler']['graphite']['prefix'],
+                :enable_profiling => node['chef_client']['handler']['graphite']['enable_profiling'],
                 :graphite_host => node['chef_client']['handler']['graphite']['host'],
                 :graphite_port => node['chef_client']['handler']['graphite']['port']
               ]


### PR DESCRIPTION
The Chef handler provides a rich dataset about execution times for all resources, which can be grouped by recipe and/or cookbook. This diff adds an option (enabled by default) to send all of this extra telemetry to graphite.
