### PR TITLE
Changes will allow users to use a local file for gem

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,3 +18,9 @@ default['chef_client']['handler']['graphite']['host'] = nil
 default['chef_client']['handler']['graphite']['port'] = nil
 default['chef_client']['handler']['graphite']['prefix'] = "chef.#{node.chef_environment}.node.#{(node['hostname']||'').downcase}"
 default['chef_client']['handler']['graphite']['enable_profiling'] = true
+
+#
+# If simple-graphite gem is available locally set this attribute e.g."/home/vagrant/gems/simple-graphite.gem"
+# If not the gem gets pulled from the ruby gems site 
+#
+default['chef_client']['handler']['gem']['location'] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,11 @@
 if node['chef_client']['handler']['graphite']['host'] && node['chef_client']['handler']['graphite']['port']
   include_recipe "chef_handler"
 
-  chef_gem "simple-graphite"
+  chef_gem "simple-graphite" do
+    if !node['chef_client']['handler']['gem']['location'].nil?
+      source node['chef_client']['handler']['gem']['location']
+    end
+  end
 
   cookbook_file "#{Chef::Config[:file_cache_path]}/chef-handler-graphite.rb" do
     source "chef-handler-graphite.rb"


### PR DESCRIPTION
The changes will allow users to specify a local file location as the source of `simple-graphite` gem file. This will help users using the cookbook behind a firewall and not able to reach the ruby gems server which will be the case with servers in enterprises.
