### PR TITLE
Allow to send custom metrics via run_context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## v0.0.12:
 
+* Enhance : Allow custom metrics insertion. Submitted by Grégoire Seux
+
 ## v0.0.10:
 
 * Enhance : Do not specify unix permissions on a windows host.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ Usage
 
 Set the host and port attributes on the node and include the "graphite_handler::default" recipe.
 
+Custom metrics
+==============
+
+To send custom metrics, fill a hash in `run_context[:graphite_handler_metrics]`.
+For instance, in a ruby_block:
+```
+run_context[:graphite_handler_metrics] ||= {}
+run_context[:graphite_handler_metrics][:monitoring_registration_time] = Benchmark.measure { register node }.real
+```
+
 Credits
 =======
 

--- a/files/default/chef-handler-graphite.rb
+++ b/files/default/chef-handler-graphite.rb
@@ -56,6 +56,10 @@ class GraphiteReporting < Chef::Handler
       metrics[:fail] = 1
     end
 
+    # user provided metrics
+    user_metrics = run_status.run_context[:graphite_handler_metrics]
+    metrics.merge!(user_metrics) if user_metrics.is_a?(Hash)
+
     if @enable_profiling
       cookbooks = Hash.new(0)
       recipes = Hash.new(0)


### PR DESCRIPTION
Using run_context, users are able to add metrics sent via the
chef_handler.
It will help to count various event (ignored failures) or measure
specific resource execution (disk format).